### PR TITLE
Update README.md

### DIFF
--- a/quality_control/3.denovo_assembly/README.md
+++ b/quality_control/3.denovo_assembly/README.md
@@ -1,5 +1,5 @@
 This script creates submission file to run SPADEs denovo assembly for a set of
-trimmed paired end reads (assummed to end with _1P.fq.gz and _1P.fq.gz).
+trimmed paired end reads (assummed to end with _1P.fq.gz and _1U.fq.gz).
 
 Run:
 


### PR DESCRIPTION
A typo in the README.md. Trimmed paired end reads are end with _1P and _1U.fq.gz